### PR TITLE
fix (#222): Add fallback to resize observer for browsers without `contentBoxSize`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,12 @@ To run the tests, run the following command in the root directory of the project
 npm run test
 ```
 
+> You may need to install Playwright browsers manually before running the tests.
+>
+> ```bash
+> npx playwright install
+> ```
+
 This will run the automated tests using the [Playwright](https://playwright.dev/) testing framework.
 
 Playwright works by running the test sites in a set of different browsers on your computer. This means that it might be necessary to install some additional browsers at this point, which Playwright will guide you through if necessary.

--- a/packages/svader/src/lib/devicePixelResizeObserver.js
+++ b/packages/svader/src/lib/devicePixelResizeObserver.js
@@ -41,20 +41,28 @@ export function devicePixelResizeObserver(node) {
     function callback(entries) {
         const entry = entries[0];
 
-        const detail = hasDevicePixelContentBox
-            ? {
-                  width: entry.devicePixelContentBoxSize[0].inlineSize,
-                  height: entry.devicePixelContentBoxSize[0].blockSize,
-              }
-            : {
-                  // Not perfect, but it's the best we can do in this case.
-                  width:
-                      entry.contentBoxSize[0].inlineSize *
-                      window.devicePixelRatio,
-                  height:
-                      entry.contentBoxSize[0].blockSize *
-                      window.devicePixelRatio,
-              };
+        let detail;
+        if (hasDevicePixelContentBox) {
+            detail = {
+                width: entry.devicePixelContentBoxSize[0].inlineSize,
+                height: entry.devicePixelContentBoxSize[0].blockSize,
+            };
+        } else if (entry.contentBoxSize) {
+            // Not perfect, but it's the best we can do in this case.
+            detail = {
+                width:
+                    entry.contentBoxSize[0].inlineSize *
+                    window.devicePixelRatio,
+                height:
+                    entry.contentBoxSize[0].blockSize * window.devicePixelRatio,
+            };
+        } else {
+            // Fallback for older browsers without contentBoxSize support
+            detail = {
+                width: entry.contentRect.width * window.devicePixelRatio,
+                height: entry.contentRect.height * window.devicePixelRatio,
+            };
+        }
 
         node.dispatchEvent(new CustomEvent("devicepixelresize", { detail }));
     }


### PR DESCRIPTION
Fixes #222 

### Reference
https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/contentBoxSize

### Changes
- Added `entry.contentBoxSize` existence check before accessing it
- Refactored nested ternary into readable if-else-if structure
- Added a mention of downloading browsers for Playwright before runnings tests to `contributing.md`

### Testing (Manual)
Verified fallback logic works using browser dev tools to simulate missing APIs

```jsx
let detail;
// ...
console.log({
    devicePixelContentBoxSizeInlineSize: entry.devicePixelContentBoxSize?.[0]?.inlineSize,
    contentBoxSizeInlineSize: entry.contentBoxSize?.[0]?.inlineSize,
    contentRectWidth: entry.contentRect?.width,
    ratio: window.devicePixelRatio,
    detail: detail,
});

node.dispatchEvent(new CustomEvent("devicepixelresize", { detail }));
// ...
```

```markdown
// Force contentRect fallback by removing both devicePixelContentBoxSize AND contentBoxSize
Object.defineProperty(ResizeObserverEntry.prototype, 'devicePixelContentBoxSize', {
  get() { return undefined; }
});

// Test resizing

Object.defineProperty(ResizeObserverEntry.prototype, 'contentBoxSize', {
  get() { return undefined; }
});

// Test again
```

To get the resize event to fire again I modified `tests-svelte4/src/routes/hello-world/webgl/+page.svelte` :

```jsx
...
<div class="container">
    <WebGlShader ... >
        ...
    </WebGlShader>
</div>

<style>
    .container {
        width: 100vw;
        height: 100vh;
    }
</style>
```

### TODO

- [ ]  Add Playwright test (maybe add in older browser to surface the issue)