### PR TITLE
Remove explicit installation of Chrome in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Dependencies
         run: npm ci
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps && npx playwright install chrome
+        run: npx playwright install --with-deps
       - name: Run Tests
         run: npm test
       - uses: actions/upload-artifact@v7


### PR DESCRIPTION
With GitHub runners' macos-latest image recently being updated to point to macos-26, explicitly installing chrome is no longer necessary and fails if attempted.